### PR TITLE
Fixed RCE on libreoffice-convert

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const async = require('async');
 const tmp = require('tmp');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 exports.convert = (document, format, filter, callback) => {
     const tempDir = tmp.dirSync({prefix: 'libreofficeConvert_', unsafeCleanup: true});
@@ -46,8 +46,8 @@ exports.convert = (document, format, filter, callback) => {
                 command += `:"${filter}"`;
             }
             command += ` --outdir ${tempDir.name} ${path.join(tempDir.name, 'source')}`;
-
-            return exec(command, callback);
+            command = command.split(' ');
+            return execFile(command[0], command.slice(1), callback);
         }],
         loadDestination: ['convert', (results, callback) =>
             async.retry({


### PR DESCRIPTION
### 📊 Metadata *

Code execution Vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-libreoffice-convert

### ⚙️ Description *

The libreoffice-convert module is vulnerable against RCE since a command is crafted using user inputs not validated and then executed, leading to arbitrary command injection.  It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *
Install the package and run the below code
```js
// poc.js
const libre = require('libreoffice-convert');
libre.convert('', 'test; touch HACKED; #', undefined, (err, done) => {
    if (err) {
      console.log(`Error converting file: ${err}`);
    }
});
```
A file named `HACKED` will be created in the current working directory.

### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
